### PR TITLE
Add support for tc39.es 

### DIFF
--- a/extension/config.json
+++ b/extension/config.json
@@ -13,7 +13,8 @@
     "whatwg.org",
     "w3c.org",
     "csswg.org",
-    "github.io"
+    "github.io",
+    "tc39.es"
   ],
   "excluded_dirs": [
     "third_party"

--- a/extension/content.js
+++ b/extension/content.js
@@ -250,9 +250,11 @@ function displaySpecmonkeyButton(anchor, elements) {
 
   // Append the SVG icon to the specmonkey button
   specMonkeyButton.appendChild(specMonkeyIcon);
-  // Append the specmonkey button after the anchor
-  anchor.insertAdjacentElement(
-    anchor.nodeType == "a" ? "afterend" : "beforeend",
+  // Append the specmonkey button after the anchor (or its heading child for section containers)
+  const headingChild = anchor.querySelector(":scope > h1, :scope > h2, :scope > h3, :scope > h4, :scope > h5, :scope > h6");
+  const insertTarget = headingChild ?? anchor;
+  insertTarget.insertAdjacentElement(
+    insertTarget.tagName.toLowerCase() === "a" ? "afterend" : "beforeend",
     specMonkeyButton
   );
 

--- a/scripts/package_extension.py
+++ b/scripts/package_extension.py
@@ -63,7 +63,13 @@ def update_manifest(
                 "'content_scripts' not found or empty in manifest.in.json."
             )
 
-        content_scripts[0]["matches"] = [f"*://*.{domain}/*" for domain in domains]
+        # Include both root and subdomain patterns since specs can live at
+        # either: e.g. tc39.es/ecma262 (root) vs html.spec.whatwg.org (subdomain).
+        content_scripts[0]["matches"] = [
+            pattern
+            for domain in domains
+            for pattern in (f"*://{domain}/*", f"*://*.{domain}/*")
+        ]
 
         # Update version
         manifest["version"] = version


### PR DESCRIPTION
Add support for viewing specs on tc39.es

1. Update config.json
2. Update domain matching patterns, as tc39.es/ecma262 lives on root-domain, whereas html.spec.whatwg.org lives on sub-domain.
3. Insert specmonkey button for tc39.es

result: 

<img width="763" height="443" alt="image" src="https://github.com/user-attachments/assets/7de76ff9-4f4c-471a-9fd9-ec7a404d7558" />
